### PR TITLE
Add MPLAB-X 6.30 and XC8 compiler support

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,7 +23,8 @@ A Nix overlay for microchip development -- intended for use in per-project envir
 - [[#adding-packages][Adding packages]]
   - [[#xc16][XC16]]
   - [[#mplab-x][MPLAB-X]]
-  - [[#xc8-xc32-xc-dsc-etc][XC8, XC32, XC-DSC etc.]]
+  - [[#xc8][XC8]]
+  - [[#xc32-xc-dsc-etc][XC32, XC-DSC etc.]]
 - [[#improvement-opportunities][Improvement opportunities]]
   - [[#material--quality-of-life-improvements][Material / quality of life improvements]]
   - [[#pedantic--to-satisfy-my-inner-anal-retentive][Pedantic / to satisfy my inner anal retentive]]
@@ -41,6 +42,9 @@ I've refactored them a bit and packaged as a flake for instant gratification.
 Currently this provides packages for the following, to meet my own immediate needs:
 - xc16 v1.61
 - xc16 v2.10
+- xc8 v2.50
+- xc8 v3.10
+- xc8 v4.00
 - mplab-x v6.15
 - mplab-x v6.20
 - mplab-x v6.30
@@ -137,9 +141,15 @@ And then add a new line to [[./pkgs/default.nix]]:
 #+end_src
 
 
-** XC8, XC32, XC-DSC etc.
+** XC8
 
-Adding packages for the other Microchip compilers should (I believe) be as simple as copying the XC16 subtree and making some minor adaptations. Another github user, =Fuwn=, has forked this repo and already done so for XC32 v4.40 -- [[https://github.com/Fuwn/nix-microchip][here]].
+XC8 is packaged in the same manner as XC16 -- adding a new version just requires a new version/hash file in [[./pkgs/xc8]] and a line in [[./pkgs/default.nix]].
+
+The =mplab-x= package bundles XC16 only. Use the =mplab-xc8= package for an MPLAB-X wrapped with XC8 instead, or override the =xc8= / =xc16= parameters of the mplab-x package to bundle any combination.
+
+** XC32, XC-DSC etc.
+
+Adding packages for the other Microchip compilers should (I believe) be as simple as copying the XC16 or XC8 subtree and making some minor adaptations. Another github user, =Fuwn=, has forked this repo and already done so for XC32 v4.40 -- [[https://github.com/Fuwn/nix-microchip][here]].
 
 
 * Improvement opportunities

--- a/README.org
+++ b/README.org
@@ -20,6 +20,7 @@ A Nix overlay for microchip development -- intended for use in per-project envir
 * Table of Contents                                         :TOC_2_gh:noexport:
 - [[#overview][Overview]]
 - [[#usage][Usage]]
+  - [[#udev-rules][Udev rules]]
 - [[#adding-packages][Adding packages]]
   - [[#xc16][XC16]]
   - [[#mplab-x][MPLAB-X]]
@@ -99,6 +100,35 @@ N.B. I'm using nixpkgs-unstable, as that's what I'm tracking for NixOS on my dev
       };
   }
 #+end_src
+
+** Udev rules
+
+MPLAB-X enumerates hardware tools (PICkit, ICD, SNAP etc.) by trying to open every USB device on the bus. Without udev rules granting access, every attempt fails and the build console fills with noise like:
+
+#+begin_example
+Error getting handle for device 0: Access denied (insufficient permissions)
+#+end_example
+
+These messages are harmless if you program via a bootloader -- builds work fine regardless. They only matter if you want to use a hardware programmer/debugger, which will not be usable until the rules are installed.
+
+The =mplab-x-unwrapped= package ships Microchip's udev rules in =lib/udev/rules.d=, but udev runs on the host -- outside the bubble-wrapped environment -- so they must be installed at system level. On NixOS:
+
+#+begin_src nix
+  services.udev.packages = [ pkgs.mplab-x-unwrapped ]; # with the overlay applied
+  # or, without the overlay:
+  # services.udev.packages = [ microchip.packages.x86_64-linux.mplab-x-unwrapped ];
+#+end_src
+
+...then rebuild and replug the device (or run =sudo udevadm control --reload-rules && sudo udevadm trigger=).
+
+On other distros, copy the rules into =/etc/udev/rules.d/= instead:
+
+#+begin_src sh
+  sudo cp $(nix build .#mplab-x-unwrapped --print-out-paths)/lib/udev/rules.d/* /etc/udev/rules.d/
+  sudo udevadm control --reload-rules && sudo udevadm trigger
+#+end_src
+
+The rules grant world read/write (=MODE="666"=) on Microchip/Atmel/J-Link USB devices, so no group membership is required.
 
 * Adding packages
 
@@ -215,7 +245,9 @@ This is likely too much effort... though there's some prior art for xc32 here:
 https://github.com/ElectricRCAircraftGuy/Microchip_XC32_Compiler
 
 
-** TODO Investigate / fix the noisy permission errors during build
+** DONE Investigate / fix the noisy permission errors during build
+Explained and addressed -- see [[#udev-rules][Udev rules]]. MPLAB-X probes every USB device while scanning for hardware tools, and each probe fails unless the host has udev rules granting access. Original notes below:
+
 Building from mplab-x works fine in my limited testing, though I see some noisy error message along the following lines in the build console...
 #+begin_example
 Error getting handle for device 0: Access denied (insufficient permissions)

--- a/README.org
+++ b/README.org
@@ -43,6 +43,7 @@ Currently this provides packages for the following, to meet my own immediate nee
 - xc16 v2.10
 - mplab-x v6.15
 - mplab-x v6.20
+- mplab-x v6.30
 
 Adding additional versions is trivial -- see instructions in the section [[Adding packages]].
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737885589,
-        "narHash": "sha256-Zf0hSrtzaM1DEz8//+Xs51k/wdSajticVrATqDrfQjg=",
+        "lastModified": 1783522502,
+        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "852ff1d9e153d8875a83602e03fdef8a63f0ecf8",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
       #   };
     in
     {
-      formatter.${system} = pkgs.nixfmt-rfc-style;
+      formatter.${system} = pkgs.nixfmt;
 
       # Your custom packages
       # Accessible through 'nix build', 'nix shell', etc

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,8 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
 
-  outputs = inputs@{ nixpkgs, self, ... }:
+  outputs =
+    inputs@{ nixpkgs, self, ... }:
     let
       # Supported systems for your flake packages, shell, etc.
       system = "x86_64-linux";
@@ -36,7 +37,10 @@
       #     inherit system;
       #     config.allowUnfree = true;
       #   };
-    in {
+    in
+    {
+      formatter.${system} = pkgs.nixfmt-rfc-style;
+
       # Your custom packages
       # Accessible through 'nix build', 'nix shell', etc
       # packages = forAllSystems (system: import ./pkgs { pkgs = pkgsForSystem system; });

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -10,6 +10,10 @@ pkgs : rec {
    xc16_1_61 = pkgs.callPackage ./xc16/1.61.nix { };
    # xc16 = xc16_2_10; #i.e. default to latest version we've bothered to package
    xc16 = xc16_1_61; #i.e. default to the version we're using for current production builds
+   xc8_4_00 = pkgs.callPackage ./xc8/4.00.nix { };
+   xc8_3_10 = pkgs.callPackage ./xc8/3.10.nix { };
+   xc8_2_50 = pkgs.callPackage ./xc8/2.50.nix { };
+   xc8 = xc8_4_00; #i.e. default to latest version we've bothered to package
    mplab-x-unwrapped_6_30 = pkgs.callPackage ./mplab-x-unwrapped/6.30.nix { };
    mplab-x-unwrapped_6_20 = pkgs.callPackage ./mplab-x-unwrapped/6.20.nix { };
    mplab-x-unwrapped_6_15 = pkgs.callPackage ./mplab-x-unwrapped/6.15.nix { };
@@ -22,7 +26,7 @@ pkgs : rec {
    # mplab-xc16 = mplab-xc16_2_10;
 
    #If adding support for additional microchip compilers, could adopt a pattern like the following
-   # mplab-xc8 = pkgs.callPackage ./mplab-x { inherit mplab-x-unwrapped xc8; };
+   mplab-xc8 = pkgs.callPackage ./mplab-x { inherit mplab-x-unwrapped xc8; };
    mplab-xc16 = pkgs.callPackage ./mplab-x { inherit mplab-x-unwrapped xc16; };
    # mplab-xc32 = pkgs.callPackage ./mplab-x { inherit mplab-x-unwrapped xc32; };
    # mplab-xc-dsc = pkgs.callPackage ./mplab-x { inherit mplab-x-unwrapped xc-dsc; };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -10,9 +10,10 @@ pkgs : rec {
    xc16_1_61 = pkgs.callPackage ./xc16/1.61.nix { };
    # xc16 = xc16_2_10; #i.e. default to latest version we've bothered to package
    xc16 = xc16_1_61; #i.e. default to the version we're using for current production builds
+   mplab-x-unwrapped_6_30 = pkgs.callPackage ./mplab-x-unwrapped/6.30.nix { };
    mplab-x-unwrapped_6_20 = pkgs.callPackage ./mplab-x-unwrapped/6.20.nix { };
    mplab-x-unwrapped_6_15 = pkgs.callPackage ./mplab-x-unwrapped/6.15.nix { };
-   mplab-x-unwrapped = mplab-x-unwrapped_6_20;
+   mplab-x-unwrapped = mplab-x-unwrapped_6_30;
    #FIXME: Rework this to pass an xc16 version as a parameter to mplab-x package rather than abusing the default..
    mplab-x = pkgs.callPackage ./mplab-x { inherit mplab-x-unwrapped xc16; };
 

--- a/pkgs/mplab-x-unwrapped/6.30.nix
+++ b/pkgs/mplab-x-unwrapped/6.30.nix
@@ -1,0 +1,4 @@
+import ./common.nix {
+  version = "6.30";
+  hash = "sha256-TK78qj9yp3Vjndq9ATa1XdgwoIbgerjGm6V/zSVpZKQ=";
+}

--- a/pkgs/mplab-x/default.nix
+++ b/pkgs/mplab-x/default.nix
@@ -15,7 +15,17 @@
 , gtk3
 , gtk-engine-murrine
 , libdrm
+, libx11
+, libxcb
+, libxcomposite
+, libxdamage
+, libxext
+, libxfixes
+, libxi
 , libxkbcommon
+, libxrandr
+, libxrender
+, libxtst
 , libusb1
 , libxslt
 , mesa
@@ -26,7 +36,6 @@
 , rsync
 , systemdLibs
 , writeShellApplication
-, xorg
 # , microchip-xc8
 , xc16
 # , microchip-xc32
@@ -58,16 +67,16 @@ let
       nss
       pango
       systemdLibs
-      xorg.libX11
-      xorg.libXcomposite
-      xorg.libXdamage
-      xorg.libXext
-      xorg.libXfixes
-      xorg.libXi
-      xorg.libXrandr
-      xorg.libXrender
-      xorg.libXtst
-      xorg.libxcb
+      libx11
+      libxcb
+      libxcomposite
+      libxdamage
+      libxext
+      libxfixes
+      libxi
+      libxrandr
+      libxrender
+      libxtst
     ];
   };
 

--- a/pkgs/mplab-x/default.nix
+++ b/pkgs/mplab-x/default.nix
@@ -36,8 +36,8 @@
 , rsync
 , systemdLibs
 , writeShellApplication
-# , microchip-xc8
-, xc16
+, xc8 ? null
+, xc16 ? null
 # , microchip-xc32
 # , microchip-xc-dsc
 }:
@@ -83,8 +83,6 @@ let
   stage2 = writeShellApplication {
     name = "mplab_ide-wrapper";
     runtimeInputs = [ execline fuse-overlayfs rsync ];
-    # mkdir "$rt/overlay/opt/microchip/xc8"
-    # ln -s ${microchip-xc8} "$rt/overlay/opt/microchip/xc8/v${microchip-xc8.version}"
     # mkdir "$rt/overlay/opt/microchip/xc32"
     # ln -s ${microchip-xc32} "$rt/overlay/opt/microchip/xc32/v${microchip-xc32.version}"
     # mkdir "$rt/overlay/opt/microchip/xc-dsc"
@@ -109,8 +107,14 @@ let
       done
 
 
-      mkdir "$rt/overlay/opt/microchip/xc16"
-      ln -s ${xc16} "$rt/overlay/opt/microchip/xc16/v${xc16.version}"
+      ${lib.optionalString (xc16 != null) ''
+        mkdir "$rt/overlay/opt/microchip/xc16"
+        ln -s ${xc16} "$rt/overlay/opt/microchip/xc16/v${xc16.version}"
+      ''}
+      ${lib.optionalString (xc8 != null) ''
+        mkdir "$rt/overlay/opt/microchip/xc8"
+        ln -s ${xc8} "$rt/overlay/opt/microchip/xc8/v${xc8.version}"
+      ''}
 
       # Make and mount (with FUSE) the newroot subdirectory.
       mkdir "$rt/newroot"

--- a/pkgs/mplab-x/default.nix
+++ b/pkgs/mplab-x/default.nix
@@ -126,6 +126,10 @@ let
       mount --rbind /home "$rt/newroot/home"
       mount --rbind /proc "$rt/newroot/proc"
       mount --rbind /run  "$rt/newroot/run"
+      # N.B. /sys must be a real sysfs mount: fuse-overlayfs cannot traverse it as
+      # a lower layer, and without it libusb enumerates no USB devices, so MPLAB
+      # never sees programmers/debuggers (PICkit, ICD, ...).
+      mount --rbind /sys  "$rt/newroot/sys"
       mount --rbind /tmp  "$rt/newroot/tmp"
       mount --rbind /var  "$rt/newroot/var"
 

--- a/pkgs/xc8/2.50.nix
+++ b/pkgs/xc8/2.50.nix
@@ -1,0 +1,4 @@
+import ./common.nix {
+  version = "2.50";
+  hash = "sha256-uIMJpU+saFwmWTNxC0Q370Mt/xoZw1eu/7zR4kc/6jM=";
+}

--- a/pkgs/xc8/3.10.nix
+++ b/pkgs/xc8/3.10.nix
@@ -1,0 +1,4 @@
+import ./common.nix {
+  version = "3.10";
+  hash = "sha256-YogDuW9GilmB1rwdCl5sf6gJ5Nh+PMqWGAXiqFf1hG4=";
+}

--- a/pkgs/xc8/4.00.nix
+++ b/pkgs/xc8/4.00.nix
@@ -1,0 +1,4 @@
+import ./common.nix {
+  version = "4.00";
+  hash = "sha256-c11lurCPpDktqdubWmJNGzJ0Nq71fSNxkmWJIeiM/QY=";
+}

--- a/pkgs/xc8/common.nix
+++ b/pkgs/xc8/common.nix
@@ -1,0 +1,69 @@
+{ version, hash }:
+
+{ lib, stdenvNoCC, bubblewrap, buildFHSEnv, fakeroot, fetchurl, glibc, rsync }:
+
+let
+  fhsEnv = buildFHSEnv {
+    name = "mplab-x-build-fhs-env";
+    targetPkgs = pkgs: [ fakeroot glibc ];
+  };
+
+in stdenvNoCC.mkDerivation rec {
+  # See https://www.microchip.com/en-us/tools-resources/archives/mplab-ecosystem for microchip installer back-catalogue
+  pname = "xc8";
+  inherit version;
+  src = fetchurl {
+    url =
+      "https://ww1.microchip.com/downloads/aemDocuments/documents/DEV/ProductDocuments/SoftwareTools/xc8-v${version}-full-install-linux-x64-installer.run";
+    # N.B. Nix uses a 32-bit hash encoding. Use 'nix hash path <filename>' to generate
+    inherit hash;
+  };
+
+  nativeBuildInputs = [ bubblewrap rsync ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    install $src installer.run
+
+    runHook postUnpack
+  '';
+  installPhase = ''
+    runHook preInstall
+
+    rsync -a ${fhsEnv.fhsenv}/ chroot/
+    find chroot -type d -exec chmod 755 {} \;
+    echo "root:x:0:0:root:/root:/bin/bash" > chroot/etc/passwd
+    echo "root:x:0:root" > chroot/etc/group
+    mkdir -p chroot/tmp/home
+
+    echo "$out" >outdir.txt
+
+    # N.B. --proc is required: the xc8 installer runs a manifest check (bin/verifyinst)
+    # that crashes without /proc, which the installer misreports as corrupted files.
+    bwrap \
+      --bind chroot / \
+      --bind /nix /nix \
+      --proc /proc \
+      --ro-bind installer.run /installer \
+      --setenv HOME /tmp/home \
+      -- /bin/fakeroot /installer \
+      ${lib.optionalString (lib.versionOlder version "4.00")
+        "--LicenseType FreeMode --netservername localhost"} \
+      --mode unattended \
+      --prefix $out
+
+    runHook postInstall
+  '';
+  dontFixup = true;
+
+  meta = with lib; {
+    homepage =
+      "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers";
+    description =
+      "Microchip's MPLAB XC8 C compiler toolchain for 8-bit PIC and AVR microcontrollers (MCUs)";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ remexre nyadiia ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Hello, thanks for this very useful nix flake.

This PR add support for MPLAB-X 6.30 and XC8 compiler. Claude code was used for the compiler addition and udev rules.

 **Update nixpkgs flake input** — also fixes the deprecated `xorg.*` package references in the mplab-x wrapper (`xorg.libX11` → `libx11`, etc.)

  **MPLAB-X v6.30** — new version file following the existing pattern; `mplab-x-unwrapped` now defaults to 6.30

  **XC8 compiler support (v2.50, v3.10, v4.00)** — packaged like XC16, with version + hash files over a shared `common.nix`:
  - New packages: `xc8_2_50`, `xc8_3_10`, `xc8_4_00` (default `xc8` = 4.00), plus `mplab-xc8` (MPLAB-X bundled with XC8)
  - The mplab-x wrapper now takes optional `xc8`/`xc16` parameters and links whichever compilers are provided; the default `mplab-x` package is unchanged (XC16 only)
  - Two installer quirks handled in `common.nix`: the post-install manifest check (`bin/verifyinst`) crashes without `/proc` mounted (misreported by the installer as "corrupted files"), and v4.00 dropped the `--LicenseType`/`--netservername` options, so they're only passed to older versions

  **README: udev rules section** — documents how to install the rules shipped in `mplab-x-unwrapped` (via `services.udev.packages` on NixOS) so hardware programmers/debuggers work, and explains the noisy "Access denied" USB errors